### PR TITLE
質問に回答できる

### DIFF
--- a/app/controllers/admin/answers_controller.rb
+++ b/app/controllers/admin/answers_controller.rb
@@ -1,0 +1,15 @@
+class Admin::AnswersController < ApplicationController
+  def create
+    @question = Question.find(params[:question_id])
+    @answer = @question.build_answer(answer_params)
+    @answer.save!
+    @question.completed!
+    redirect_to admin_question_path(@question)
+  end
+
+  private
+
+  def answer_params
+    params.require(:answer).permit(:title, :content)
+  end
+end

--- a/app/controllers/admin/answers_controller.rb
+++ b/app/controllers/admin/answers_controller.rb
@@ -2,8 +2,12 @@ class Admin::AnswersController < ApplicationController
   def create
     @question = Question.find(params[:question_id])
     @answer = @question.build_answer(answer_params)
-    @answer.save!
-    @question.completed!
+    
+    ApplicationRecord.transaction do
+      @answer.save!
+      @question.completed!
+    end
+    
     redirect_to admin_question_path(@question)
   end
 

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -1,11 +1,19 @@
 class Admin::QuestionsController < ApplicationController
-  def new; end
+  def new
+    @question = Question.find(params[:id])
+  end
 
-  def edit; end
-
-  def show; end
+  def show
+    @question = Question.find(params[:id])
+  end
 
   def index
     @questions = Question.all
+  end
+
+  private
+
+  def answer_params
+    params.require(:answer).permit(:title, :content)
   end
 end

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -1,8 +1,4 @@
 class Admin::QuestionsController < ApplicationController
-  def new
-    @question = Question.find(params[:id])
-  end
-
   def show
     @question = Question.find(params[:id])
   end

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -13,7 +13,7 @@ h1 質問一覧
     tbody
       - @questions.each do |question|
         tr
-          td= question.title
+          td= link_to question.title, admin_question_path(question)
           td= question.content  
           - if question.wait?
             td= '回答待ち'

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -1,5 +1,13 @@
 h1 質問一覧
 
+= form_with url: admin_questions_path, local: true do |f|
+  .form-group 
+    = f.label :status, '回答ステータス'
+    br
+    = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
+       { include_blank: true }, class: 'form-select'
+  = f.submit nil, value: '検索する', class: 'btn btn-primary'
+
 .mb-3
   table.table.table-hover
     thead.thead-default
@@ -16,11 +24,11 @@ h1 質問一覧
           td= link_to question.title, admin_question_path(question)
           td= question.content  
           - if question.wait?
-            td= '回答待ち'
+            td= '未読'
           - elsif question.working?
-            td= '回答作成中'
+            td= '作成中'
           - else
             td= '回答済み'
-          td= question.created_at
-          td= question.updated_at
+          td= l question.created_at
+          td= l question.updated_at
           td= question.local_government_id

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -1,13 +1,5 @@
 h1 質問一覧
 
-= form_with url: admin_questions_path, local: true do |f|
-  .form-group 
-    = f.label :status, '回答ステータス'
-    br
-    = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
-       { include_blank: true }, class: 'form-select'
-  = f.submit nil, value: '検索する', class: 'btn btn-primary'
-
 .mb-3
   table.table.table-hover
     thead.thead-default

--- a/app/views/admin/questions/show.html.slim
+++ b/app/views/admin/questions/show.html.slim
@@ -17,10 +17,10 @@ table.table.table-hover
       td= @question.content
     tr 
       th= Question.human_attribute_name(:created_at)
-      td= @question.created_at
+      td= l @question.created_at
     tr 
       th= Question.human_attribute_name(:updated_at)
-      td= @question.updated_at
+      td= l @question.updated_at
 
 - if @question.answer.nil?
   = form_with model: [:admin, @question, @question.build_answer], local: true do |f|
@@ -46,7 +46,7 @@ table.table.table-hover
         td= @question.answer.content 
       tr 
         th= Question.human_attribute_name(:created_at)
-        td= @question.answer.created_at
+        td= l @question.answer.created_at
       tr 
         th= Question.human_attribute_name(:updated_at)
-        td= @question.answer.updated_at
+        td= l @question.answer.updated_at

--- a/app/views/admin/questions/show.html.slim
+++ b/app/views/admin/questions/show.html.slim
@@ -1,0 +1,41 @@
+h1 質問に回答する
+
+.nav.justify-content-end
+  = link_to '質問一覧に戻る', admin_questions_path, class: 'nav-link'
+
+table.table.table-hover 
+  tbody 
+    tr 
+      th= Question.human_attribute_name(:title)
+      td= @question.title
+    tr 
+      th= Question.human_attribute_name(:content)
+      td= @question.content
+    tr 
+      th= Question.human_attribute_name(:created_at)
+      td= @question.created_at
+    tr 
+      th= Question.human_attribute_name(:updated_at)
+      td= @question.updated_at
+
+- if @question.answer.nil?
+  = form_with model: [:admin, @question, @question.build_answer], local: true do |f|
+    .form-group 
+      = f.label :title
+      = f.text_field :title, class: 'form-control'
+    .form-group
+      = f.label :content
+      = f.text_area :content, rows: 5, class: 'form-control'
+    = f.submit nil, value: '回答する', class: 'btn btn-primary'
+- else 
+  table.table.table-hover 
+    tbody 
+      tr 
+        th= Question.human_attribute_name(:id)
+        td= @question.answer.id
+      tr 
+        th= Question.human_attribute_name(:title)
+        td= @question.answer.title
+      tr 
+        th= Question.human_attribute_name(:content)
+        td= @question.answer.content 

--- a/app/views/admin/questions/show.html.slim
+++ b/app/views/admin/questions/show.html.slim
@@ -1,10 +1,14 @@
-h1 質問に回答する
+h1 回答画面
 
 .nav.justify-content-end
   = link_to '質問一覧に戻る', admin_questions_path, class: 'nav-link'
 
+h3 質問内容
 table.table.table-hover 
   tbody 
+    tr 
+      th= Question.human_attribute_name(:id)
+      td= @question.id
     tr 
       th= Question.human_attribute_name(:title)
       td= @question.title
@@ -29,6 +33,7 @@ table.table.table-hover
     = f.submit nil, value: '回答する', class: 'btn btn-primary'
 - else 
   table.table.table-hover 
+    h3 回答内容
     tbody 
       tr 
         th= Question.human_attribute_name(:id)
@@ -39,3 +44,9 @@ table.table.table-hover
       tr 
         th= Question.human_attribute_name(:content)
         td= @question.answer.content 
+      tr 
+        th= Question.human_attribute_name(:created_at)
+        td= @question.answer.created_at
+      tr 
+        th= Question.human_attribute_name(:updated_at)
+        td= @question.answer.updated_at

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,8 @@ module Qcarea
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.time_zone = 'Asia/Tokyo'
+    config.i18n.default_locale = :ja
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,10 +13,14 @@ ja:
       question:
         id: ID
         title: 質問タイトル
-        body: 質問本文
+        content: 質問本文
         created_at: 質問日時
         updated_at: 更新日時
         local_government_id: 役所ID
+      answer:
+        id: ID
+        title: 回答タイトル
+        content: 回答本文
   date:
     abbr_day_names:
     - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,8 @@ ja:
         id: ID
         title: 回答タイトル
         content: 回答本文
+        created_at: 回答日時
+        updated_at: 回答更新日時
   date:
     abbr_day_names:
     - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,6 +14,7 @@ ja:
         id: ID
         title: 質問タイトル
         content: 質問本文
+        status: 回答ステータス
         created_at: 質問日時
         updated_at: 更新日時
         local_government_id: 役所ID
@@ -23,6 +24,12 @@ ja:
         content: 回答本文
         created_at: 回答日時
         updated_at: 回答更新日時
+  enums:
+    question:
+      status:
+        wait: 未読
+        working: 作成中
+        completed: 回答済み
   date:
     abbr_day_names:
     - 日
@@ -191,7 +198,7 @@ ja:
   time:
     am: 午前
     formats:
-      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      default: "%Y/%m/%d %H:%M:%S"
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,12 +24,6 @@ ja:
         content: 回答本文
         created_at: 回答日時
         updated_at: 回答更新日時
-  enums:
-    question:
-      status:
-        wait: 未読
-        working: 作成中
-        completed: 回答済み
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@
 
 Rails.application.routes.draw do
   namespace :admin do
-    resources :questions
+    resources :questions do
+      resources :answers
+    end
   end
   root to: 'questions#index'
   resources :questions


### PR DESCRIPTION
## 概要
役所側が、質問に対して回答できる機能を実装する

## 確認内容
- 回答フォームを作成し、特定の質問に回答を入力できるようにする
- 回答フォームの内容を回答テーブルに保存する
- 回答した内容を確認できる画面を出力する
- 「回答待ち」のステータスを「回答済み」に変更する

## 実行結果
以下のとおり、出力を確認しました。
- 以下の画面の「テスト」に回答します。
<img width="1431" alt="スクリーンショット 2022-09-30 17 25 02" src="https://user-images.githubusercontent.com/112605644/193226997-4ef7e6fc-9b0e-4ab2-9b47-5f50d49cddb1.png">

- 回答フォーム
<img width="1431" alt="スクリーンショット 2022-09-30 17 25 53" src="https://user-images.githubusercontent.com/112605644/193227047-a70bf6d7-c906-431c-9df5-589e8c0f2ba3.png">

- 回答すると回答フォームの代わりに回答済みの内容を表示します。
<img width="1431" alt="スクリーンショット 2022-09-30 17 26 09" src="https://user-images.githubusercontent.com/112605644/193227078-93e879d0-4e2a-4967-8586-245a094bbedd.png">

- 一覧表の「回答待ち」が「回答済み」に変わっています。
<img width="1431" alt="スクリーンショット 2022-09-30 17 26 21" src="https://user-images.githubusercontent.com/112605644/193227106-e8e7e69d-aa41-4a46-9ec9-6702761fb4a2.png">
