### PR TITLE
[役所]質問の絞り込み実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,5 @@ end
 gem 'bootstrap'
 gem 'html2slim'
 gem 'slim-rails'
+gem 'rails-i18n'
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.11.0)
     execjs (2.8.1)
     ffi (1.15.5)
@@ -153,6 +155,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.7)
       actionpack (= 6.1.7)
       activesupport (= 6.1.7)
@@ -254,6 +259,7 @@ DEPENDENCIES
   bootstrap
   byebug
   capybara (>= 3.26)
+  enum_help
   html2slim
   jbuilder (~> 2.7)
   listen (~> 3.3)
@@ -261,6 +267,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7)
+  rails-i18n
   rubocop
   rubocop-rails
   sass-rails (>= 6)

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -7,10 +7,6 @@ class Admin::QuestionsController < ApplicationController
     @questions = Question.all
   end
 
-  def create
-    redirect_to admin_questions_path
-  end
-
   def search
     if params[:status].empty?
       @questions = Question.all

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -7,6 +7,19 @@ class Admin::QuestionsController < ApplicationController
     @questions = Question.all
   end
 
+  def create
+    redirect_to admin_questions_path
+  end
+
+  def search
+    if params[:status].empty?
+      @questions = Question.all
+    else
+      @questions = Question.where(status: params[:status])
+    end
+    render :index
+  end
+
   private
 
   def answer_params

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -4,16 +4,11 @@ class Admin::QuestionsController < ApplicationController
   end
 
   def index
-    @questions = Question.all
-  end
-
-  def search
-    if params[:status].empty?
+    if params[:status].nil? || params[:status].empty?
       @questions = Question.all
     else
       @questions = Question.where(status: params[:status])
     end
-    render :index
   end
 
   private

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -4,10 +4,10 @@ class Admin::QuestionsController < ApplicationController
   end
 
   def index
-    if params[:status].nil? || params[:status].empty?
-      @questions = Question.all
-    else
+    if params[:status].present?
       @questions = Question.where(status: params[:status])
+    else
+      @questions = Question.all
     end
   end
 

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -1,5 +1,13 @@
 h1 質問一覧
 
+= form_with url: admin_questions_path, local: true do |f|
+  .form-group 
+    = f.label :status, '回答ステータス'
+    br
+    = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
+       { include_blank: true }, class: 'form-select'
+  = f.submit nil, value: '検索する', class: 'btn btn-primary'
+
 .mb-3
   table.table.table-hover
     thead.thead-default

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,6 +24,12 @@ ja:
         content: 回答本文
         created_at: 回答日時
         updated_at: 回答更新日時
+  enums:
+    question:
+      status:
+        wait: 未読
+        working: 作成中
+        completed: 回答済み
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 
 Rails.application.routes.draw do
   namespace :admin do
+    post 'questions', to: 'questions#search'
     resources :questions do
       resources :answers
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   namespace :admin do
-    post 'questions', to: 'questions#search'
+    post 'questions', to: 'questions#index'
     resources :questions do
       resources :answers
     end


### PR DESCRIPTION
## 概要
役所側の質問一覧に対して、回答ステータスを使って質問を絞り込むことで未回答の質問に回答しやすくする。

## 確認内容
- プルダウンを用いて回答ステータスを選択できる画面を作成する。
- 回答ステータスを選択した状態で検索ボタンを押すと該当する回答ステータスの質問だけが出力される。空行を選択していた場合は、すべての質問を出力する。

## 実行結果
以下のとおり、出力を確認しました。

- 回答ステータス選択画面
<img width="1431" alt="スクリーンショット 2022-10-05 14 04 06" src="https://user-images.githubusercontent.com/112605644/193986934-617ecd35-9415-4674-9e2b-ba719783381f.png">

- 回答ステータスプルダウン
<img width="1440" alt="スクリーンショット 2022-10-05 14 06 27（2）" src="https://user-images.githubusercontent.com/112605644/193986965-ea737b30-b54a-4ca8-b8eb-a6f3355707c0.png">

- 「未読」状態選択後の質問一覧
<img width="1431" alt="スクリーンショット 2022-10-05 14 08 35" src="https://user-images.githubusercontent.com/112605644/193987002-1d6e33a9-ca50-4d0c-b789-56085f30e31e.png">