### PR TITLE
[役所]ログイン機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
@@ -255,6 +256,7 @@ PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   bootstrap
   byebug

--- a/app/controllers/admin/answers_controller.rb
+++ b/app/controllers/admin/answers_controller.rb
@@ -3,7 +3,7 @@ class Admin::AnswersController < Admin::ApplicationController
   layout 'admin'
 
   def create
-    @question = Question.find(params[:question_id])
+    @question = current_lg.questions.find(params[:question_id])
     @answer = @question.build_answer(answer_params)
     
     ApplicationRecord.transaction do

--- a/app/controllers/admin/answers_controller.rb
+++ b/app/controllers/admin/answers_controller.rb
@@ -1,4 +1,4 @@
-class Admin::AnswersController < ApplicationController
+class Admin::AnswersController < Admin::ApplicationController
 
   layout 'admin'
 

--- a/app/controllers/admin/answers_controller.rb
+++ b/app/controllers/admin/answers_controller.rb
@@ -1,4 +1,7 @@
 class Admin::AnswersController < ApplicationController
+
+  layout 'admin'
+
   def create
     @question = Question.find(params[:question_id])
     @answer = @question.build_answer(answer_params)

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,14 @@
+class Admin::ApplicationController < ApplicationController
+  helper_method :current_lg
+  before_action :admin_login_required
+
+  private
+
+  def current_lg
+    @current_lg ||= LocalGovernment.find_by(id: session[:local_government_id]) if session[:local_government_id]
+  end
+
+  def admin_login_required
+    redirect_to admin_login_path unless current_lg
+  end
+end

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -1,4 +1,4 @@
-class Admin::QuestionsController < ApplicationController
+class Admin::QuestionsController < Admin::ApplicationController
 
   layout 'admin'
 
@@ -8,9 +8,9 @@ class Admin::QuestionsController < ApplicationController
 
   def index
     if params[:status].present?
-      @questions = Question.where(status: params[:status], local_government_id: current_lg)
+      @questions = current_lg.questions.where(status: params[:status])
     else
-      @questions = Question.where(local_government_id: current_lg.id)
+      @questions = current_lg.questions
     end
   end
 

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -7,11 +7,8 @@ class Admin::QuestionsController < Admin::ApplicationController
   end
 
   def index
-    if params[:status].present?
-      @questions = current_lg.questions.where(status: params[:status])
-    else
-      @questions = current_lg.questions
-    end
+    @questions = current_lg.questions
+    @questions = @questions.where(status: params[:status]) if params[:status].present?
   end
 
   private

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -1,13 +1,16 @@
 class Admin::QuestionsController < ApplicationController
+
+  layout 'admin'
+
   def show
     @question = Question.find(params[:id])
   end
 
   def index
     if params[:status].present?
-      @questions = Question.where(status: params[:status])
+      @questions = Question.where(status: params[:status], local_government_id: current_lg)
     else
-      @questions = Question.all
+      @questions = Question.where(local_government_id: current_lg.id)
     end
   end
 

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,4 +1,4 @@
-class Admin::SessionsController < ApplicationController
+class Admin::SessionsController < Admin::ApplicationController
   skip_before_action :admin_login_required
 
   def new; end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,0 +1,27 @@
+class Admin::SessionsController < ApplicationController
+  skip_before_action :admin_login_required
+
+  def new; end
+
+  def create
+    lg = LocalGovernment.find_by(email: session_params[:email])
+
+    if lg&.authenticate(session_params[:password])
+        session[:local_government_id] = lg.id
+        redirect_to admin_questions_path, notice: 'ログインしました'
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    reset_session
+    redirect_to admin_login_path, notice: 'ログアウトしました'
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email, :password)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::Base
+  helper_method :current_lg
+  before_action :admin_login_required
+
+  private
+
+  def current_lg
+    @current_lg ||= LocalGovernment.find_by(id: session[:local_government_id]) if session[:local_government_id]
+  end
+
+  def admin_login_required
+    redirect_to admin_login_path unless current_lg
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,2 @@
 class ApplicationController < ActionController::Base
-  helper_method :current_lg
-  before_action :admin_login_required
-
-  private
-
-  def current_lg
-    @current_lg ||= LocalGovernment.find_by(id: session[:local_government_id]) if session[:local_government_id]
-  end
-
-  def admin_login_required
-    redirect_to admin_login_path unless current_lg
-  end
 end

--- a/app/models/local_government.rb
+++ b/app/models/local_government.rb
@@ -1,3 +1,4 @@
 class LocalGovernment < ApplicationRecord
   has_many :questions, dependent: :destroy
+  has_secure_password
 end

--- a/app/views/admin/sessions/new.html.slim
+++ b/app/views/admin/sessions/new.html.slim
@@ -1,0 +1,13 @@
+h1 市区町村ログイン
+
+= form_with scope: :session, local: true do |f|
+  .form-group
+    = f.label :name, '市区町村名'
+    = f.text_field :name, class: 'form-control', id: 'session-name'
+  .form-group 
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control', id: 'session-email'
+  .form-group 
+    = f.label :password, 'パスワード'
+    = f.text_field :password, class: 'form-control', id: 'session-password'
+  = f.submit 'ログインする', class: 'btn btn-primary'

--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -11,8 +11,14 @@ html
     link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous"
     script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"
   body
-    .app-title.navbar.navbar-expand-md.navbar-light.bg-light
+    .app-title.navbar.navbar-expand-lg.navbar-light.bg-light
       .navbar-brand Q care A 
 
+      ul.navbar-nav.me-auto 
+        - if current_lg 
+          li.nav-item= link_to '質問一覧', admin_questions_path, class: 'nav-link'
+          li.nav-item= link_to 'ログアウト', admin_logout_path, method: :delete, class: 'nav-link'
+      ul.navbar-nav.ms-auto 
+        li.nav-item= current_lg.name 
     .container
     = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@
 Rails.application.routes.draw do
   namespace :admin do
     post 'questions', to: 'questions#index'
+    get '/login', to: 'sessions#new'
+    post '/login', to: 'sessions#create'
+    delete '/logout', to: 'sessions#destroy'
     resources :questions do
       resources :answers
     end


### PR DESCRIPTION
## 概要
- 役所側でログインすることで管理者ユーザーとして操作できる
- 役所IDと一致する質問だけが表示される

## 確認内容
- adminのログイン画面を表示することができた
- 名前、email、パスワードを入力することでログインをして、質問一覧ページに入ることができた
- URLからアクセスしようとしてもログイン画面に移動するようにした
- ログインした役所ユーザーの質問だけが出力された

## 実行結果
以下のとおり、出力を確認しました。

- ログイン画面
<img width="1461" alt="スクリーンショット 2022-10-06 13 26 40" src="https://user-images.githubusercontent.com/112605644/194216135-d9ade854-4684-42f7-8932-6965f3af146b.png">

- ログイン後の質問一覧画面（役所ID:4の場合）
<img width="1461" alt="スクリーンショット 2022-10-06 13 26 59" src="https://user-images.githubusercontent.com/112605644/194216183-c9af6282-9c2b-455e-bd13-0eddff905ddb.png">