### PR TITLE
[介護]施設職員テーブルの作成

### DIFF
--- a/app/models/nursing_facility.rb
+++ b/app/models/nursing_facility.rb
@@ -1,4 +1,5 @@
 class NursingFacility < ApplicationRecord
   has_many :questions, dependent: :destroy
+  has_many :staffs, dependent: :destroy
   belongs_to :local_government
 end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -1,0 +1,3 @@
+class Staff < ApplicationRecord
+  has_secure_password
+end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -1,3 +1,4 @@
 class Staff < ApplicationRecord
+  belongs_to :nursing_facility
   has_secure_password
 end

--- a/db/migrate/20221012023825_create_staffs.rb
+++ b/db/migrate/20221012023825_create_staffs.rb
@@ -1,0 +1,13 @@
+class CreateStaffs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :staffs do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.integer :nursing_facility_id, null: false
+      t.string :password_digest
+
+      t.timestamps
+      t.index :email, unique: true
+    end
+  end
+end

--- a/db/migrate/20221012023825_create_staffs.rb
+++ b/db/migrate/20221012023825_create_staffs.rb
@@ -8,6 +8,7 @@ class CreateStaffs < ActiveRecord::Migration[6.1]
 
       t.timestamps
       t.index :email, unique: true
+      t.index :nursing_facility_id
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_12_014842) do
+ActiveRecord::Schema.define(version: 2022_10_12_023825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,16 @@ ActiveRecord::Schema.define(version: 2022_10_12_014842) do
     t.integer "nursing_facility_id"
     t.index ["local_government_id"], name: "index_questions_on_local_government_id"
     t.index ["nursing_facility_id"], name: "index_questions_on_nursing_facility_id"
+  end
+
+  create_table "staffs", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.integer "nursing_facility_id", null: false
+    t.string "password_digest"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_staffs_on_email", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 2022_10_12_023825) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_staffs_on_email", unique: true
+    t.index ["nursing_facility_id"], name: "index_staffs_on_nursing_facility_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## 概要
介護側の介護施設の職員テーブルを作成する

## 確認内容
- 職員テーブルを作成した
- 介護施設テーブルと関連付けを行った

## 実行結果
コンソール上で登録できることを確認しました。
```
irb(main):001:0> staff = Staff.create(name: '介護 太郎', email: 'taro.kaigo@example.com', nursing_facility_id
: 1, password: 'password', password_confirmation: 'password')

irb(main):002:0> staff
=> 
#<Staff:0x00007fe1b986ff90
 id: 1,
 name: "介護 太郎",
 email: "taro.kaigo@example.com",
 nursing_facility_id: 1,
 password_digest: "[FILTERED]",
 created_at: Wed, 12 Oct 2022 16:37:49.713892000 JST +09:00,
 updated_at: Wed, 12 Oct 2022 16:37:49.713892000 JST +09:00>
```

関連付けを確認しました
```
irb(main):003:0> nf = Staff.first.nursing_facility

irb(main):004:0> nf
=> 
#<NursingFacility:0x00007fe1b8025278
 id: 1,
 name: "特養ながおか",
 local_government_id: 4,
 created_at: Wed, 12 Oct 2022 16:14:13.666760000 JST +09:00,
 updated_at: Wed, 12 Oct 2022 16:14:13.666760000 JST +09:00>
irb(main):005:0> 
```

close #20 