### PR TITLE
[介護]職員を登録できるようにする

### DIFF
--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -35,6 +35,12 @@ class StaffsController < ApplicationController
     end
   end
 
+  def destroy
+    @staff = Staff.find(params[:id])
+    @staff.destroy
+    redirect_to staffs_url, notice: "職員「#{@staff.name}」の登録を削除しました"
+  end
+
   private
 
   def staff_params

--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -12,7 +12,11 @@ class StaffsController < ApplicationController
       render :new
     end
   end
-  
+
+  def index
+    @staffs = Staff.all
+  end
+
   private
 
   def staff_params

--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -21,6 +21,20 @@ class StaffsController < ApplicationController
     @staff = Staff.find(params[:id])
   end
 
+  def edit
+    @staff = Staff.find(params[:id])
+  end
+
+  def update
+    @staff = Staff.find(params[:id])
+
+    if @staff.update(staff_params)
+      redirect_to staff_url(@staff), notice: "職員「#{@staff.name}」を更新しました。"
+    else
+      render :edit
+    end
+  end
+
   private
 
   def staff_params

--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -17,6 +17,10 @@ class StaffsController < ApplicationController
     @staffs = Staff.all
   end
 
+  def show
+    @staff = Staff.find(params[:id])
+  end
+
   private
 
   def staff_params

--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -1,0 +1,21 @@
+class StaffsController < ApplicationController
+  def new
+    @staff = Staff.new
+  end
+
+  def create
+    @staff = Staff.new(staff_params)
+
+    if @staff.save
+      redirect_to staff_url(@staff), notice: "職員「#{@staff.name}」を登録しました。"
+    else
+      render :new
+    end
+  end
+  
+  private
+
+  def staff_params
+    params.require(:staff).permit(:name, :email, :nursing_facility_id, :password, :password_confirmation)
+  end
+end

--- a/app/views/staffs/edit.html.slim
+++ b/app/views/staffs/edit.html.slim
@@ -1,0 +1,22 @@
+h1 介護職員登録の編集
+
+.nav.justify-content-end 
+  = link_to '職員一覧', staffs_path, class: 'nav-link'
+
+= form_with model: @staff, local: true do |f|
+  .form-group 
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .form-group 
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control'
+  .form-group 
+    = f.label :nursing_facility_id, '介護施設ID'
+    = f.text_field :nursing_facility_id, class: 'form-control'
+  .form-group 
+    = f.label :password, 'パスワード'
+    = f.text_field :password, class: 'form-control'
+  .form-group 
+    = f.label :password_confirmation, 'パスワード（確認）'
+    = f.text_field :password_confirmation, class: 'form-control'
+  = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/staffs/index.html.slim
+++ b/app/views/staffs/index.html.slim
@@ -1,0 +1,24 @@
+h1 職員一覧
+
+= link_to '登録', new_staff_path, class: 'btn btn-primary'
+
+.mb-3 
+table.table.table-hover 
+  thead.thead-default 
+    tr 
+      th= Staff.human_attribute_name(:name)
+      th= Staff.human_attribute_name(:email)
+      th= Staff.human_attribute_name(:nursing_facility_id)
+      th= Staff.human_attribute_name(:created_at)
+      th= Staff.human_attribute_name(:updated_at)
+      th 
+  tbody 
+    - @staffs.each do |staff|
+      tr 
+        td= link_to staff.name, staff 
+        td= staff.email 
+        td= staff.nursing_facility_id 
+        td= l staff.created_at 
+        td= l staff.updated_at
+        td 
+

--- a/app/views/staffs/index.html.slim
+++ b/app/views/staffs/index.html.slim
@@ -22,4 +22,4 @@ table.table.table-hover
         td= l staff.updated_at
         td 
           =link_to '編集', edit_staff_path(staff), class: 'btn btn-primary mr-3'
-
+          =link_to '削除', staff, method: :delete, data: { confirm: "職員「#{staff.name}」登録を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/staffs/index.html.slim
+++ b/app/views/staffs/index.html.slim
@@ -21,4 +21,5 @@ table.table.table-hover
         td= l staff.created_at 
         td= l staff.updated_at
         td 
+          =link_to '編集', edit_staff_path(staff), class: 'btn btn-primary mr-3'
 

--- a/app/views/staffs/new.html.slim
+++ b/app/views/staffs/new.html.slim
@@ -1,5 +1,8 @@
 h1 介護職員登録
 
+.nav.justify-content-end 
+  = link_to '職員一覧', staffs_path, class: 'nav-link'
+
 = form_with model: @staff, local: true do |f|
   .form-group 
     = f.label :name, '名前'

--- a/app/views/staffs/new.html.slim
+++ b/app/views/staffs/new.html.slim
@@ -1,0 +1,19 @@
+h1 介護職員登録
+
+= form_with model: @staff, local: true do |f|
+  .form-group 
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .form-group 
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control'
+  .form-group 
+    = f.label :nursing_facility_id, '介護施設ID'
+    = f.text_field :nursing_facility_id, class: 'form-control'
+  .form-group 
+    = f.label :password, 'パスワード'
+    = f.text_field :password, class: 'form-control'
+  .form-group 
+    = f.label :password_confirmation, 'パスワード（確認）'
+    = f.text_field :password_confirmation, class: 'form-control'
+  = f.submit '登録する', class: 'btn btn-primary'

--- a/app/views/staffs/show.html.slim
+++ b/app/views/staffs/show.html.slim
@@ -22,4 +22,5 @@ table.table.table-hover
     tr
       th= Staff.human_attribute_name(:updated_at)
       td= l @staff.updated_at
+= link_to '編集', edit_staff_path, class: 'btn btn-primary mr-3'
 

--- a/app/views/staffs/show.html.slim
+++ b/app/views/staffs/show.html.slim
@@ -1,0 +1,25 @@
+h1 職員詳細
+
+.nav.justify-content-end 
+  = link_to '職員一覧', staffs_path, class: 'nav-link'
+table.table.table-hover 
+  tbody 
+    tr 
+      th= Staff.human_attribute_name(:id)
+      td= @staff.id
+    tr 
+      th= Staff.human_attribute_name(:name)
+      td= @staff.name
+    tr 
+      th= Staff.human_attribute_name(:email)
+      td= @staff.email
+    tr 
+      th= Staff.human_attribute_name(:nursing_facility_id)
+      td= @staff.nursing_facility_id
+    tr 
+      th= Staff.human_attribute_name(:created_at)
+      td= l @staff.created_at
+    tr
+      th= Staff.human_attribute_name(:updated_at)
+      td= l @staff.updated_at
+

--- a/app/views/staffs/show.html.slim
+++ b/app/views/staffs/show.html.slim
@@ -23,4 +23,4 @@ table.table.table-hover
       th= Staff.human_attribute_name(:updated_at)
       td= l @staff.updated_at
 = link_to '編集', edit_staff_path, class: 'btn btn-primary mr-3'
-
+= link_to '削除', @staff, method: :delete, data: { confirm: "職員「#{@staff.name}」登録を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,6 +25,13 @@ ja:
         content: 回答本文
         created_at: 回答日時
         updated_at: 回答更新日時
+      staff:
+        id: ID
+        name: 氏名
+        email: メールアドレス
+        nursing_facility_id: 介護施設ID
+        created_at: 登録日時
+        updated_at: 更新日時
   enums:
     question:
       status:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   end
   root to: 'questions#index'
   resources :questions
+  resources :staffs
 end


### PR DESCRIPTION
## 概要
介護職員を登録する機能を実装し、編集・削除できるようにする。

## 確認内容
- 職員が新規登録できることを確認した
- 登録済み職員を編集できることを確認した
- 一覧画面、詳細画面が表示されることを確認した
- 削除できることを確認した

## 実行結果
- 新規登録画面
<img width="1461" alt="スクリーンショット 2022-10-13 10 03 56" src="https://user-images.githubusercontent.com/112605644/195475900-c477f881-ee08-408c-9e14-e20071b47e2f.png">

- 登録後の詳細画面
<img width="1461" alt="スクリーンショット 2022-10-13 10 04 17" src="https://user-images.githubusercontent.com/112605644/195475940-fa7224a1-9718-410b-a3dd-439ed2d18f81.png">

- 一覧画面
<img width="1461" alt="スクリーンショット 2022-10-13 10 04 32" src="https://user-images.githubusercontent.com/112605644/195475950-58641ac0-da5b-4fbc-a38a-15821ceac2cf.png">