### PR TITLE
[介護]ログインページを作成する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  helper_method :current_staff
+
+  private
+
+  def current_staff
+    @current_staff ||= Staff.find_by(id: session[:staff_id]) if session[:staff_id]
+  end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,7 +5,7 @@ class QuestionsController < ApplicationController
 
   def index
     @question = Question.new
-    @questions = Question.all
+    @questions = current_staff.nursing_facility.questions
   end
 
   def create

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class QuestionsController < ApplicationController
+  before_action :login_required
+
   def index
     @question = Question.new
     @questions = Question.all
@@ -27,5 +29,9 @@ class QuestionsController < ApplicationController
 
   def question_params
     params.require(:question).permit(:service, :title, :content, :status, :attachment)
+  end
+
+  def login_required
+    redirect_to login_path unless current_staff
   end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -12,10 +12,8 @@ class QuestionsController < ApplicationController
     @question = Question.new(question_params)
     @question.attachment = params[:question][:attachment]
 
-    #市町村選択機能は、職員登録機能実装時に作成するため、今は仮のIDを入力
-    @question.local_government_id = 4
-    #介護施設選択機能は、職員登録機能実装時に作成するため、今は仮のIDを入力
-    @question.nursing_facility_id = 1
+    @question.local_government_id = current_staff.nursing_facility.local_government_id
+    @question.nursing_facility_id = current_staff.nursing_facility.id
     
     ApplicationRecord.transaction do
       @question.save!

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,6 +12,11 @@ class SessionsController < ApplicationController
     end
   end
 
+  def destroy
+    reset_session
+    redirect_to login_path, notice: 'ログアウトしました。'
+  end
+  
   private
 
   def session_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,20 @@
+class SessionsController < ApplicationController
+  def new; end
+
+  def create
+    staff = Staff.find_by(email: session_params[:email])
+
+    if staff&.authenticate(session_params[:password])
+      session[:staff_id] = staff.id
+      redirect_to root_url, notice: 'ログインしました。'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email, :password)
+  end
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,6 +13,16 @@ html
   body
     .app-title.navbar.navbar-expand-md.navbar-light.bg-light
       .navbar-brand Q care A 
-
+      - if current_staff 
+        ul.navbar-nav.me-auto 
+          li.nav-item= link_to '質問トップ', questions_path, class: 'nav-link'
+          li.nav-item= link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link'
+        ul.navbar-nav.ms-auto 
+          li.nav-item= "#{current_staff.nursing_facility.name}/"
+          li.nav-item= current_staff.name
+      - else 
+        ul.navbar-nav.me-auto
+          li.nav-item= link_to 'ログイン', login_path, class: 'nav-link'
+        
     .container
     = yield

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -38,6 +38,7 @@ h1 質問一覧
               th= Question.human_attribute_name(:created_at)
               th= Question.human_attribute_name(:updated_at)
               th= Question.human_attribute_name(:local_government_id)
+              th= Question.human_attribute_name(:nursing_facility_id)
           tbody
             - @questions.each do |question|
               tr
@@ -48,3 +49,4 @@ h1 質問一覧
                 td= l question.created_at
                 td= l question.updated_at
                 td= question.local_government_id
+                td= question.nursing_facility_id

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,0 +1,10 @@
+h1 ログイン
+
+= form_with scope: :session, local: true do |f|
+  .form-group 
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control', id: 'session_email'
+  .form-group 
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control', id: 'session_password'
+  = f.submit 'ログインする', class: 'btn btn-primary'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,7 @@ ja:
         updated_at: 更新日時
         local_government_id: 役所ID
         service: サービス種別
+        nursing_facility_id: 施設ID
       answer:
         id: ID
         title: 回答タイトル

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,7 @@ Rails.application.routes.draw do
   root to: 'questions#index'
   resources :questions
   resources :staffs
+  get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
 end


### PR DESCRIPTION
## 概要
介護職員がログインできる機能を実装する

## 確認内容
- 登録済みの介護職員がログインフォームに入力することでログインできることを確認した
- ログインをしないと質問ページが見られないことを確認した
- 質問投稿時、ログイン職員の施設IDとその施設の役所IDが質問テーブルに保存されることを確認した
- 質問一覧画面が、ログイン中の所属施設の質問だけになっていることを確認した

## 実行結果
- ログインフォーム
<img width="1543" alt="スクリーンショット 2022-10-14 11 21 09" src="https://user-images.githubusercontent.com/112605644/195747462-88eada00-c49f-4bad-9d21-7373bd17a802.png">

- ログイン後の質問一覧
<img width="1543" alt="スクリーンショット 2022-10-14 11 22 50" src="https://user-images.githubusercontent.com/112605644/195747496-0dfa2d70-caa1-4401-8c5c-84c8d8ccd978.png">

close #16 