### PR TITLE
[介護]質問の絞り込みができる

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -6,6 +6,8 @@ class QuestionsController < ApplicationController
   def index
     @question = Question.new
     @questions = current_staff.nursing_facility.questions
+    @questions = @questions.where(service: params[:service]) if params[:service].present?
+    @questions = @questions.where(status: params[:status]) if params[:status].present?
   end
 
   def create

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -27,7 +27,18 @@ h1 質問一覧
         .mt-3 
           = f.submit nil, value: '質問を投稿', class: 'btn btn-primary'
     .tab-pane id="qa2"
-      .mb-3
+      = form_with url: questions_path, method: 'get', local: true do |f|
+        .form-group.mt-3
+          = f.label :service, 'サービス種別'
+          = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
+          { include_blank: true }
+        .form-group.my-3
+          = f.label :status, '回答ステータス'
+          = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
+          { include_blank: true }
+        = f.submit nil, value: '検索する', class: 'btn btn-primary'
+
+        .mb-3
         table.table.table-hover
           thead.thead-default
             tr


### PR DESCRIPTION
## 概要
介護側の質問一覧表の絞り込み機能を実装する

## 確認内容
- 一覧画面に絞り込み検索フォームを作成した
- サービス種別、回答ステータスによって質問が抽出されることを確認した

## 実行結果
- 検索フォーム
<img width="1543" alt="スクリーンショット 2022-10-17 14 32 14" src="https://user-images.githubusercontent.com/112605644/196096724-9b16f6b7-8ad3-4b3d-b6c7-e07254c959ab.png">

- 絞り込み結果
<img width="1543" alt="スクリーンショット 2022-10-17 14 31 43" src="https://user-images.githubusercontent.com/112605644/196096760-bb61aa0c-0fa8-4d26-affc-fc4b3a9fe802.png">

close #13 