### PR TITLE
質問作成フォームにタグを選択できるようにする

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -28,7 +28,7 @@ class QuestionsController < ApplicationController
   private
 
   def question_params
-    params.require(:question).permit(:service, :title, :content, :status, :attachment)
+    params.require(:question).permit(:service, :title, :content, :status, :attachment, :categories => [])
   end
 
   def login_required

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -19,6 +19,12 @@ h1 質問一覧
         .form-group
           = f.label :content, '質問本文'
           = f.text_area :content, rows: 5, class: 'form-control', id: 'question_content'
+        .form-group
+          = f.label :categories, '質問タグ'
+          br
+          = f.collection_check_boxes(:categories, Question.categories.pairs, :last, :first) do |b|
+            = b.label { b.check_box + b.text }
+            br
         .form-group 
           .mt-3
             = f.label :attachment, '添付ファイル'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,16 @@ ja:
           has_many: "%{record}が存在しているので削除できません"
     model:
       question: 質問
+    active_flag:
+      question:
+        categories:
+          operation: 運営基準
+          personnel: 人員基準
+          system: 制度改正
+          application: 申請・届出関係
+          invoice: 請求
+          addition: 加算
+          error: 過誤調整
     attributes:
       question:
         id: ID


### PR DESCRIPTION
## 概要
- 質問作成フォームでタグを選択できるようにする
- submitしたら選択したタグが保存される

## 確認内容
- 質問作成フォームにチェックボックスを作成してタグを複数選択できるようにした
- 質問テーブルにタグが保存されることを確認した

## 実行結果
- 質問作成フォーム
<img width="1543" alt="スクリーンショット 2022-10-18 13 56 09" src="https://user-images.githubusercontent.com/112605644/196339914-63ba9773-912b-4e41-8025-fd7c6e08130b.png">

- 質問テーブルに保存
```
irb(main):001:0> Question.last
  Question Load (0.4ms)  SELECT "questions".* FROM "questions" ORDER BY "questions"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> 
#<Question:0x00007faedbb3be88
 id: 51,
 title: "タグテスト３",
 content: "タグテスト３",
 status: "wait",
 local_government_id: 4,
 created_at: Tue, 18 Oct 2022 13:56:17.079824000 JST +09:00,
 updated_at: Tue, 18 Oct 2022 13:56:17.079824000 JST +09:00,
 service: "helper",
 nursing_facility_id: 1,
 categories: 7>
```

close #43 