### PR TITLE
質問一覧ページにタグを表示する

### DIFF
--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -7,8 +7,8 @@ class Admin::QuestionsController < Admin::ApplicationController
   end
 
   def index
-    @questions = current_lg.questions
-    @questions = @questions.where(status: params[:status]) if params[:status].present?
+    @questions = current_lg.questions.order(created_at: :desc)
+    @questions = @questions.where(status: params[:status]).order(created_at: :desc) if params[:status].present?
   end
 
   private

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,9 +5,9 @@ class QuestionsController < ApplicationController
 
   def index
     @question = Question.new
-    @questions = current_staff.nursing_facility.questions
-    @questions = @questions.where(service: params[:service]) if params[:service].present?
-    @questions = @questions.where(status: params[:status]) if params[:status].present?
+    @questions = current_staff.nursing_facility.questions.order(created_at: :desc)
+    @questions = @questions.where(service: params[:service]).order(created_at: :desc) if params[:service].present?
+    @questions = @questions.where(status: params[:status]).order(created_at: :desc) if params[:status].present?
   end
 
   def create

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -1,14 +1,13 @@
 h1 質問一覧
 
 = form_with url: admin_questions_path, local: true do |f|
-  .form-group 
+  .form-group.my-3
     = f.label :status, '回答ステータス'
-    br
     = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
-       { include_blank: true }, class: 'form-select'
+       { include_blank: true }
   = f.submit nil, value: '検索する', class: 'btn btn-primary'
 
-.mb-3
+.my-3
   table.table.table-hover
     thead.thead-default
       tr

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -17,6 +17,7 @@ h1 質問一覧
         th= Question.human_attribute_name(:created_at)
         th= Question.human_attribute_name(:updated_at)
         th= Question.human_attribute_name(:local_government_id)
+        th= Question.human_attribute_name(:categories)
     tbody
       - @questions.each do |question|
         tr
@@ -26,3 +27,5 @@ h1 質問一覧
           td= l question.created_at
           td= l question.updated_at
           td= question.local_government_id
+          - question.categories.to_human.each do |category|
+            td= category

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -14,18 +14,18 @@ h1 質問一覧
         th= Question.human_attribute_name(:title)
         th= Question.human_attribute_name(:content)
         th= Question.human_attribute_name(:status)
+        th= Question.human_attribute_name(:categories)
         th= Question.human_attribute_name(:created_at)
         th= Question.human_attribute_name(:updated_at)
         th= Question.human_attribute_name(:local_government_id)
-        th= Question.human_attribute_name(:categories)
     tbody
       - @questions.each do |question|
         tr
           td= link_to question.title, admin_question_path(question)
           td= question.content  
           td= question.status_i18n
+          td= question.categories.to_human.join(' ')
           td= l question.created_at
           td= l question.updated_at
           td= question.local_government_id
-          - question.categories.to_human.each do |category|
-            td= category
+

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -23,12 +23,7 @@ h1 質問一覧
         tr
           td= link_to question.title, admin_question_path(question)
           td= question.content  
-          - if question.wait?
-            td= '未読'
-          - elsif question.working?
-            td= '作成中'
-          - else
-            td= '回答済み'
+          td= question.status_i18n
           td= l question.created_at
           td= l question.updated_at
           td= question.local_government_id

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -52,11 +52,11 @@ h1 質問一覧
               th= Question.human_attribute_name(:title)
               th= Question.human_attribute_name(:content)
               th= Question.human_attribute_name(:status)
+              th= Question.human_attribute_name(:categories)
               th= Question.human_attribute_name(:created_at)
               th= Question.human_attribute_name(:updated_at)
               th= Question.human_attribute_name(:local_government_id)
               th= Question.human_attribute_name(:nursing_facility_id)
-              th= Question.human_attribute_name(:categories)
           tbody
             - @questions.each do |question|
               tr
@@ -64,9 +64,9 @@ h1 質問一覧
                 td= link_to question.title, question 
                 td= question.content 
                 td= question.status_i18n
+                td= question.categories.to_human.join(' ')
                 td= l question.created_at
                 td= l question.updated_at
                 td= question.local_government_id
                 td= question.nursing_facility_id
-                - question.categories.to_human.each do |category|
-                  td= category
+

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -56,6 +56,7 @@ h1 質問一覧
               th= Question.human_attribute_name(:updated_at)
               th= Question.human_attribute_name(:local_government_id)
               th= Question.human_attribute_name(:nursing_facility_id)
+              th= Question.human_attribute_name(:categories)
           tbody
             - @questions.each do |question|
               tr
@@ -67,3 +68,5 @@ h1 質問一覧
                 td= l question.updated_at
                 td= question.local_government_id
                 td= question.nursing_facility_id
+                - question.categories.to_human.each do |category|
+                  td= category

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -30,6 +30,7 @@ ja:
         local_government_id: 役所ID
         service: サービス種別
         nursing_facility_id: 施設ID
+        categories: 質問タグ
       answer:
         id: ID
         title: 回答タイトル


### PR DESCRIPTION
## 概要
- 質問一覧ページに選択したタグが表示されるようにする

## 確認内容
- タグ付きのテスト質問を３件投稿し、質問一覧ページで選択したタグが表示されていることを確認した
- 質問一覧を日付で降順に表示した

## 実行結果
- 役所側の質問一覧ページ
<img width="1574" alt="スクリーンショット 2022-10-18 17 35 38" src="https://user-images.githubusercontent.com/112605644/196381022-030231b5-e055-474b-91ba-4b1051dd6d7b.png">

- 介護側の質問一覧ページ
<img width="1574" alt="スクリーンショット 2022-10-18 17 34 34" src="https://user-images.githubusercontent.com/112605644/196380995-ca91ebfc-4a9e-4f3d-a013-eb04a4ad61d3.png">

close #44 