### PR TITLE
[介護]質問の詳細ページを作成する

### DIFF
--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -3,7 +3,7 @@ class Admin::QuestionsController < Admin::ApplicationController
   layout 'admin'
 
   def show
-    @question = Question.find(params[:id])
+    @question = current_lg.questions.find(params[:id])
   end
 
   def index

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -11,7 +11,7 @@ class QuestionsController < ApplicationController
   end
 
   def show
-    @question = Question.find(params[:id])
+    @question = current_staff.nursing_facility.questions.find(params[:id])
   end
 
   def create

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -10,6 +10,10 @@ class QuestionsController < ApplicationController
     @questions = @questions.where(status: params[:status]).order(created_at: :desc) if params[:status].present?
   end
 
+  def show
+    @question = Question.find(params[:id])
+  end
+
   def create
     @question = Question.new(question_params)
     @question.attachment = params[:question][:attachment]

--- a/app/views/admin/questions/show.html.slim
+++ b/app/views/admin/questions/show.html.slim
@@ -16,6 +16,9 @@ table.table.table-hover
       th= Question.human_attribute_name(:content)
       td= @question.content
     tr 
+      th= Question.human_attribute_name(:categories)
+      td= @question.categories.to_human.join(' ')
+    tr 
       th= Question.human_attribute_name(:created_at)
       td= l @question.created_at
     tr 

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -1,0 +1,29 @@
+h1 質問詳細
+
+.nav.justify-content-end
+  = link_to '質問一覧に戻る', admin_questions_path, class: 'nav-link'
+
+table.table.table-hover 
+  tbody 
+    tr 
+      th= Question.human_attribute_name(:id)
+      td= @question.id
+    tr 
+      th= Question.human_attribute_name(:title)
+      td= @question.title
+    tr 
+      th= Question.human_attribute_name(:content)
+      td= @question.content
+    tr 
+      th= Question.human_attribute_name(:status)
+      td= @question.status_i18n
+    tr 
+      th= Question.human_attribute_name(:categories)
+      td= @question.categories.to_human.join(' ')
+    tr 
+      th= Question.human_attribute_name(:created_at)
+      td= l @question.created_at
+    tr 
+      th= Question.human_attribute_name(:updated_at)
+      td= l @question.updated_at
+


### PR DESCRIPTION
## 概要
介護側の質問詳細ページを作成する

## 確認内容
- 質問一覧画面から詳細画面に遷移して、質問の詳細が表示されることを確認した
- 役所側の既存の詳細画面に、タグの情報が表示されていることを確認した

## 実行結果
- 介護側の質問詳細ページ
<img width="1574" alt="スクリーンショット 2022-10-19 10 35 51" src="https://user-images.githubusercontent.com/112605644/196577662-e84ef721-3728-463b-9fa4-f3c9bc1d2d16.png">

- 役所側の質問詳細ページ
<img width="1574" alt="スクリーンショット 2022-10-19 10 44 38" src="https://user-images.githubusercontent.com/112605644/196577693-248381de-6d36-4b02-8b06-dcec4f4f8bbe.png">

close #32 