### PR TITLE
サービス種別の選択機能を拡張する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,20 @@
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
+ * or vendor/assets/stylesheets of plugins, if any, can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the bottom of the
+ * compiled file so the styles you add here take precedence over styles defined in any styles
+ * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
+ * file per style scope.
+ *
+ *= require_tree .
+ *= require_self
+ *= require bootstrap/dist/css/bootstrap
+ *= require select2/dist/css/select2
+ *= require @ttskch/select2-bootstrap4-theme/dist/select2-bootstrap4
+ */
+
 @import "bootstrap";

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -8,6 +8,7 @@ class Admin::QuestionsController < Admin::ApplicationController
 
   def index
     @questions = current_lg.questions.order(created_at: :desc)
+    @questions = @questions.where(service: params[:service]).order(created_at: :desc) if params[:service].present?
     @questions = @questions.where(status: params[:status]).order(created_at: :desc) if params[:status].present?
   end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,8 @@ import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
+import ('jquery')
+import 'bootstrap'
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/index.js
+++ b/app/javascript/packs/index.js
@@ -1,0 +1,10 @@
+import $ from 'jquery'
+import 'select2'
+
+$(function () {
+  $('.js-searchable').select2({
+    dropdownAutoWidth: true,
+    placeholder: "サービス種別を入力",
+    theme: 'bootstrap5'
+  });
+});

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -19,6 +19,7 @@ h1 質問一覧
   table.table.table-hover
     thead.thead-default
       tr
+        th= Question.human_attribute_name(:service)
         th= Question.human_attribute_name(:title)
         th= Question.human_attribute_name(:content)
         th= Question.human_attribute_name(:status)
@@ -29,6 +30,7 @@ h1 質問一覧
     tbody
       - @questions.each do |question|
         tr
+          td= question.service_i18n
           td= link_to question.title, admin_question_path(question)
           td= question.content  
           td= question.status_i18n

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -1,7 +1,5 @@
 h1 質問一覧
 
-= javascript_pack_tag 'index'
-
 = form_with url: admin_questions_path, local: true do |f|
   .form-group.row.mt-3
     = f.label :service, 'サービス種別'

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -1,6 +1,14 @@
 h1 質問一覧
 
+= javascript_pack_tag 'index'
+
 = form_with url: admin_questions_path, local: true do |f|
+  .form-group.row.mt-3
+    = f.label :service, 'サービス種別'
+    .col-sm-4
+      .border.rounded
+        = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
+        { include_blank: true }, class: 'form-control js-searchable'
   .form-group.my-3
     = f.label :status, '回答ステータス'
     = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\

--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -8,6 +8,7 @@ html
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_pack_tag 'index'
     link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous"
     script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"
   body

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,6 +8,7 @@ html
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_pack_tag 'index'
     link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous"
     script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"
   body

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -1,5 +1,7 @@
 h1 質問一覧
 
+= javascript_pack_tag 'index'
+
 .p-3
   ul.nav.nav-tabs
     li.nav-item 
@@ -11,8 +13,10 @@ h1 質問一覧
       = form_with model: @question, local: true do |f|
         .form-group 
           = f.label :service, 'サービス種別'
-          = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
-            {}, class: 'form-select'
+          .col-sm-4
+            .border.rounded
+              = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
+              { include_blank: true }, class: 'form-control js-searchable'
         .form-group 
           = f.label :title, '質問タイトル'
           = f.text_field :title, class: 'form-control', id: 'question_title'
@@ -34,14 +38,17 @@ h1 質問一覧
           = f.submit nil, value: '質問を投稿', class: 'btn btn-primary'
     .tab-pane id="qa2"
       = form_with url: questions_path, method: 'get', local: true do |f|
-        .form-group.mt-3
-          = f.label :service, 'サービス種別'
-          = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
-          { include_blank: true }
+        .form-group.row.mt-3
+              = f.label :service, 'サービス種別'
+              .col-sm-4
+                .border.rounded
+                  = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
+                  { include_blank: true }, class: 'form-control js-searchable'
         .form-group.my-3
           = f.label :status, '回答ステータス'
-          = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
-          { include_blank: true }
+          .col-sm-1
+            = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
+            { include_blank: true }, class: 'form-control'
         = f.submit nil, value: '検索する', class: 'btn btn-primary'
 
         .mb-3

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -1,7 +1,5 @@
 h1 質問一覧
 
-= javascript_pack_tag 'index'
-
 .p-3
   ul.nav.nav-tabs
     li.nav-item 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,16 @@
   "name": "qcarea",
   "private": true,
   "dependencies": {
+    "@popperjs/core": "^2.11.6",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
+    "@ttskch/select2-bootstrap4-theme": "^1.5.2",
+    "bootstrap": "^5.2.2",
+    "jquery": "^3.6.1",
+    "popper.js": "^1.16.1",
+    "select2": "^4.1.0-rc.0",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,6 +989,11 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@popperjs/core@^2.11.6":
+  version "2.11.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
+  integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
+
 "@rails/actioncable@^6.0.0":
   version "6.1.7"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.7.tgz#8b4506925d3f7146a70941e4db7ce9dda99f99ae"
@@ -1049,6 +1054,11 @@
     webpack-assets-manifest "^3.1.1"
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
+
+"@ttskch/select2-bootstrap4-theme@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@ttskch/select2-bootstrap4-theme/-/select2-bootstrap4-theme-1.5.2.tgz#3b4519b349f3e7831c28752a1e9617312a192656"
+  integrity sha512-gAj8qNy/VYwQDBkACm0USM66kxFai8flX83ayRXPNhzZckEgSqIBB9sM74SCM3ssgeX+ZVy4BifTnLis+KpIyg==
 
 "@types/glob@^7.1.1":
   version "7.2.0"
@@ -1604,6 +1614,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
+bootstrap@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.2.tgz#834e053eed584a65e244d8aa112a6959f56e27a0"
+  integrity sha512-dEtzMTV71n6Fhmbg4fYJzQsw1N29hJKO1js5ackCgIpDcGid2ETMGC6zwSYw09v05Y+oRdQ9loC54zB1La3hHQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3923,6 +3938,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.1.tgz#fab0408f8b45fc19f956205773b62b292c147a16"
+  integrity sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4873,6 +4893,11 @@ pnp-webpack-plugin@^1.7.0:
   integrity sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==
   dependencies:
     ts-pnp "^1.1.6"
+
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portfinder@^1.0.26:
   version "1.0.32"
@@ -5993,6 +6018,11 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==
+
+select2@^4.1.0-rc.0:
+  version "4.1.0-rc.0"
+  resolved "https://registry.yarnpkg.com/select2/-/select2-4.1.0-rc.0.tgz#ba3cd3901dda0155e1c0219ab41b74ba51ea22d8"
+  integrity sha512-Hr9TdhyHCZUtwznEH2CBf7967mEM0idtJ5nMtjvk3Up5tPukOLXbHUNmh10oRfeNIhj+3GD3niu+g6sVK+gK0A==
 
 selfsigned@^1.10.8:
   version "1.10.14"


### PR DESCRIPTION
## 概要
サービス種別を選択するときに使用していたセレクトボックスをselect2に拡張する

## 確認内容
- 介護側の質問一覧ページからselect2で選択できることを確認した
- select2で選択したサービス種別が従来と同じように保存されることを確認した
- 役所側と介護側の質問絞り込みするときのサービス種別選択でselect2が使用できることを確認した

## 実行結果
- 介護側の質問作成ページ
<img width="1552" alt="スクリーンショット 2022-10-21 10 38 54" src="https://user-images.githubusercontent.com/112605644/197091048-e92e99ab-5717-4284-83c4-0a3312d7c583.png">

- 介護側の絞り込み
<img width="1552" alt="スクリーンショット 2022-10-21 10 34 00" src="https://user-images.githubusercontent.com/112605644/197091120-44835332-79c7-405b-9469-5eac74df13bf.png">

- 役所側の絞り込み
<img width="1552" alt="スクリーンショット 2022-10-21 10 32 41" src="https://user-images.githubusercontent.com/112605644/197091141-a2fe25fb-6baf-4d9b-8f61-87d1fdeff05e.png">

close #33 