### PR TITLE
[介護]質問一覧ページのデザインを修正する

### DIFF
--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -55,20 +55,19 @@
                 { include_blank: true }, class: 'form-control'
           = f.submit nil, value: '検索する', class: 'btn btn-primary'
 
-          .mb-3
-          table.table.table-hover
-            thead.thead-default
-              tr
-                th= Question.human_attribute_name(:service)
-                th= Question.human_attribute_name(:title)
-                th= Question.human_attribute_name(:status)
-                th= Question.human_attribute_name(:categories)
-                th= Question.human_attribute_name(:created_at)
-            tbody
-              - @questions.each do |question|
-                tr
-                  td= question.service_i18n
-                  td= link_to question.title, question 
-                  td= question.status_i18n
-                  td= question.categories.to_human.join(' ')
-                  td= l question.created_at
+        .mb-3
+        .row.row-cols-1.row-cols-md-2.g-4
+          - @questions.each do |question|
+            .col
+              .card.mb-4.shadow-sm.h-md-250
+                .card-body
+                  .mb-2.text-success
+                    strong= question.status_i18n
+                  h5= question.title
+                  .mb-2.text-muted
+                    = l question.created_at
+                  p= question.content
+                  .small
+                    p= question.categories.to_human.join(' ')
+                  =link_to '詳細を見る', question 
+

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -47,7 +47,7 @@
                   .border.rounded
                     = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
                     { include_blank: true }, class: 'form-control js-searchable'
-            .row 
+            .row.mb-3
               .col-8
                 .row.mb-3
                   = f.label :status, '回答ステータス', class: 'col-3 col-form-label'
@@ -56,8 +56,6 @@
                     { include_blank: true }, class: 'form-control'
               .col-4
                 = f.submit nil, value: '検索する', class: 'btn btn-primary'
-
-        .mb-3
         .row.row-cols-1.row-cols-md-2.g-4
           - @questions.each do |question|
             .col

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -41,17 +41,18 @@
       .tab-pane id="qa2"
         = form_with url: questions_path, method: 'get', local: true do |f|
           .form-group
-            .row
-                = f.label :service, 'サービス種別'
-                .col-sm-4
+            .row.mb-3
+                = f.label :service, 'サービス種別', class: 'col-2 col-form-label'
+                .col-4
                   .border.rounded
                     = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
                     { include_blank: true }, class: 'form-control js-searchable'
-          .form-group.my-3
-            = f.label :status, '回答ステータス'
-            .col-sm-1
-              = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
-              { include_blank: true }, class: 'form-control'
+          .form-group
+            .row.mb-3
+              = f.label :status, '回答ステータス', class: 'col-2 col-form-label'
+              .col-4
+                = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
+                { include_blank: true }, class: 'form-control'
           = f.submit nil, value: '検索する', class: 'btn btn-primary'
 
           .mb-3

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -47,13 +47,15 @@
                   .border.rounded
                     = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
                     { include_blank: true }, class: 'form-control js-searchable'
-          .form-group
-            .row.mb-3
-              = f.label :status, '回答ステータス', class: 'col-2 col-form-label'
+            .row 
+              .col-8
+                .row.mb-3
+                  = f.label :status, '回答ステータス', class: 'col-3 col-form-label'
+                  .col-6
+                    = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
+                    { include_blank: true }, class: 'form-control'
               .col-4
-                = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
-                { include_blank: true }, class: 'form-control'
-          = f.submit nil, value: '検索する', class: 'btn btn-primary'
+                = f.submit nil, value: '検索する', class: 'btn btn-primary'
 
         .mb-3
         .row.row-cols-1.row-cols-md-2.g-4

--- a/app/views/questions/index.html.slim
+++ b/app/views/questions/index.html.slim
@@ -61,23 +61,14 @@
               tr
                 th= Question.human_attribute_name(:service)
                 th= Question.human_attribute_name(:title)
-                th= Question.human_attribute_name(:content)
                 th= Question.human_attribute_name(:status)
                 th= Question.human_attribute_name(:categories)
                 th= Question.human_attribute_name(:created_at)
-                th= Question.human_attribute_name(:updated_at)
-                th= Question.human_attribute_name(:local_government_id)
-                th= Question.human_attribute_name(:nursing_facility_id)
             tbody
               - @questions.each do |question|
                 tr
                   td= question.service_i18n
                   td= link_to question.title, question 
-                  td= question.content 
                   td= question.status_i18n
                   td= question.categories.to_human.join(' ')
                   td= l question.created_at
-                  td= l question.updated_at
-                  td= question.local_government_id
-                  td= question.nursing_facility_id
-


### PR DESCRIPTION
## 概要
介護側の質問一覧ページに対し、Bootstrapを用いてデザインを調整した

## 実装内容
- 絞り込みフォームを水平に揃えた
- テスト用に表示していた一覧ページに不要なカラムを削除した（編集できない仕様なので、更新日時の削除等）

## 実行結果
調整後の質問フォーム
<img width="1406" alt="スクリーンショット 2022-10-31 16 45 04" src="https://user-images.githubusercontent.com/112605644/198957329-987b8f2f-4f0b-4617-98d8-7326e8d5aa8b.png">

