### PR TITLE
[介護]質問詳細ページのデザインを修正する

### DIFF
--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -3,7 +3,7 @@
     h3 質問詳細
 
   .nav.justify-content-end
-    = link_to '質問一覧に戻る', admin_questions_path, class: 'nav-link'
+    = link_to '質問一覧に戻る', questions_path, class: 'nav-link'
 
   table.table.table-hover 
     tbody 

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -1,29 +1,31 @@
-h1 質問詳細
+.container
+  .py-3.text-center
+    h3 質問詳細
 
-.nav.justify-content-end
-  = link_to '質問一覧に戻る', admin_questions_path, class: 'nav-link'
+  .nav.justify-content-end
+    = link_to '質問一覧に戻る', admin_questions_path, class: 'nav-link'
 
-table.table.table-hover 
-  tbody 
-    tr 
-      th= Question.human_attribute_name(:id)
-      td= @question.id
-    tr 
-      th= Question.human_attribute_name(:title)
-      td= @question.title
-    tr 
-      th= Question.human_attribute_name(:content)
-      td= @question.content
-    tr 
-      th= Question.human_attribute_name(:status)
-      td= @question.status_i18n
-    tr 
-      th= Question.human_attribute_name(:categories)
-      td= @question.categories.to_human.join(' ')
-    tr 
-      th= Question.human_attribute_name(:created_at)
-      td= l @question.created_at
-    tr 
-      th= Question.human_attribute_name(:updated_at)
-      td= l @question.updated_at
+  table.table.table-hover 
+    tbody 
+      tr 
+        th= Question.human_attribute_name(:id)
+        td= @question.id
+      tr 
+        th= Question.human_attribute_name(:title)
+        td= @question.title
+      tr 
+        th= Question.human_attribute_name(:content)
+        td= @question.content
+      tr 
+        th= Question.human_attribute_name(:status)
+        td= @question.status_i18n
+      tr 
+        th= Question.human_attribute_name(:categories)
+        td= @question.categories.to_human.join(' ')
+      tr 
+        th= Question.human_attribute_name(:created_at)
+        td= l @question.created_at
+      tr 
+        th= Question.human_attribute_name(:updated_at)
+        td= l @question.updated_at
 

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -14,12 +14,13 @@
         = l @question.created_at
       .mb-4.small
         p= @question.content
-      - unless @question.answer.nil?
-        .mb-4
+      .small
+        p= @question.categories.to_human.join(' ')
+  - unless @question.answer.nil?
+    .card.mb-4.shadow-sm.h-md-250
+      .card-body.mb-4
           h5= @question.answer.title 
           .mb-2.text-muted 
             = l @question.answer.created_at
           p= @question.answer.content
-      .small
-        p= @question.categories.to_human.join(' ')
 

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -12,7 +12,14 @@
       h5= @question.title
       .mb-2.text-muted
         = l @question.created_at
-      p= @question.content
+      .mb-4.small
+        p= @question.content
+      - unless @question.answer.nil?
+        .mb-4
+          h5= @question.answer.title 
+          .mb-2.text-muted 
+            = l @question.answer.created_at
+          p= @question.answer.content
       .small
         p= @question.categories.to_human.join(' ')
 

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -5,20 +5,14 @@
   .nav.justify-content-end
     = link_to '質問一覧に戻る', questions_path, class: 'nav-link'
 
-  table.table.table-hover 
-    tbody 
-      tr 
-        th= Question.human_attribute_name(:title)
-        td= @question.title
-      tr 
-        th= Question.human_attribute_name(:content)
-        td= @question.content
-      tr 
-        th= Question.human_attribute_name(:status)
-        td= @question.status_i18n
-      tr 
-        th= Question.human_attribute_name(:categories)
-        td= @question.categories.to_human.join(' ')
-      tr 
-        th= Question.human_attribute_name(:created_at)
-        td= l @question.created_at
+  .card.mb-4.shadow-sm.h-md-250
+    .card-body
+      .mb-2.text-success
+        strong= @question.status_i18n
+      h5= @question.title
+      .mb-2.text-muted
+        = l @question.created_at
+      p= @question.content
+      .small
+        p= @question.categories.to_human.join(' ')
+

--- a/app/views/questions/show.html.slim
+++ b/app/views/questions/show.html.slim
@@ -8,9 +8,6 @@
   table.table.table-hover 
     tbody 
       tr 
-        th= Question.human_attribute_name(:id)
-        td= @question.id
-      tr 
         th= Question.human_attribute_name(:title)
         td= @question.title
       tr 
@@ -25,7 +22,3 @@
       tr 
         th= Question.human_attribute_name(:created_at)
         td= l @question.created_at
-      tr 
-        th= Question.human_attribute_name(:updated_at)
-        td= l @question.updated_at
-


### PR DESCRIPTION
## 概要
介護側の質問詳細ページに対し、Bootstrapを用いてデザインを調整した

## 実装内容
- containerを導入した
- 介護側にとって不要なカラムを削除した
- 詳細項目の表示を表形式からcard形式に変更した
- 回答がある場合、別のcardに回答を表示するようにした

## 実行結果
調整後の質問詳細ページ
<img width="1406" alt="スクリーンショット 2022-10-31 17 57 13" src="https://user-images.githubusercontent.com/112605644/198970125-60669b4d-944b-4ac9-8e21-d5749c5b4016.png">

