### PR TITLE
[介護]ログインページのデザイン修正

### DIFF
--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,10 +1,13 @@
-h1 ログイン
+.container
+  .text-center
+    h3.my-4 ログイン
 
-= form_with scope: :session, local: true do |f|
-  .form-group 
-    = f.label :email, 'メールアドレス'
-    = f.text_field :email, class: 'form-control', id: 'session_email'
-  .form-group 
-    = f.label :password, 'パスワード'
-    = f.password_field :password, class: 'form-control', id: 'session_password'
-  = f.submit 'ログインする', class: 'btn btn-primary'
+    = form_with scope: :session, local: true do |f|
+      .row.justify-content-center
+        .col-sm-4
+          .form-group
+            = f.label :email, 'メールアドレス', for: 'session_email', class: 'sr-only mb-2'
+            = f.text_field :email, class: 'form-control mb-3', id: 'session_email', placeholder: "Email address"
+            = f.label :password, 'パスワード', for: 'session_email', class: 'sr-only mb-2'
+            = f.password_field :password, class: 'form-control mb-4', id: 'session_password', placeholder: "Password"
+          = f.submit 'ログイン', class: 'btn btn-primary'


### PR DESCRIPTION
## 概要
介護側のログインページに対し、Bootstrapを用いてデザインを調整した

## 実装内容
余白をとり、中央揃えにした

## 実行結果
修正後のログインフォーム
<img width="1406" alt="スクリーンショット 2022-11-01 11 03 38" src="https://user-images.githubusercontent.com/112605644/199142996-cd314e3f-cf38-4c1d-ae68-baff16bcd8ac.png">
