### PR TITLE
[役所]質問一覧ページのデザインの修正

### DIFF
--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -2,39 +2,43 @@
   h4.my-3 質問一覧
 
   = form_with url: admin_questions_path, local: true do |f|
-    .form-group.row
-      = f.label :service, 'サービス種別'
-      .col-sm-4
-        .border.rounded
-          = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
-          { include_blank: true }, class: 'form-control js-searchable'
-    .form-group.my-3
-      = f.label :status, '回答ステータス'
-      = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
-        { include_blank: true }
-    = f.submit nil, value: '検索する', class: 'btn btn-primary'
+    .form-group
+      .row.mb-3
+        = f.label :service, 'サービス種別', class: 'col-2 col-form-label'
+        .col-4
+          .border.rounded
+            = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
+            { include_blank: true }, class: 'form-control js-searchable'
+      .row.mb-3 
+        .col-8 
+          .row.mb-3
+            = f.label :status, '回答ステータス', class: 'col-3 col-form-label'
+            .col-6
+              = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
+              { include_blank: true }, class: 'form-control'
+        .col-4
+          = f.submit nil, value: '検索する', class: 'btn btn-primary'
 
-  .my-3
-    table.table.table-hover
-      thead.thead-default
+  table.table.table-hover
+    thead.thead-default
+      tr
+        th= Question.human_attribute_name(:service)
+        th= Question.human_attribute_name(:title)
+        th= Question.human_attribute_name(:content)
+        th= Question.human_attribute_name(:status)
+        th= Question.human_attribute_name(:categories)
+        th= Question.human_attribute_name(:created_at)
+        th= Question.human_attribute_name(:updated_at)
+        th= Question.human_attribute_name(:local_government_id)
+    tbody
+      - @questions.each do |question|
         tr
-          th= Question.human_attribute_name(:service)
-          th= Question.human_attribute_name(:title)
-          th= Question.human_attribute_name(:content)
-          th= Question.human_attribute_name(:status)
-          th= Question.human_attribute_name(:categories)
-          th= Question.human_attribute_name(:created_at)
-          th= Question.human_attribute_name(:updated_at)
-          th= Question.human_attribute_name(:local_government_id)
-      tbody
-        - @questions.each do |question|
-          tr
-            td= question.service_i18n
-            td= link_to question.title, admin_question_path(question)
-            td= question.content  
-            td= question.status_i18n
-            td= question.categories.to_human.join(' ')
-            td= l question.created_at
-            td= l question.updated_at
-            td= question.local_government_id
+          td= question.service_i18n
+          td= link_to question.title, admin_question_path(question)
+          td= question.content  
+          td= question.status_i18n
+          td= question.categories.to_human.join(' ')
+          td= l question.created_at
+          td= l question.updated_at
+          td= question.local_government_id
 

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -19,8 +19,8 @@
         .col-4
           = f.submit nil, value: '検索する', class: 'btn btn-primary'
 
-  table.table.table-hover
-    thead.thead-default
+  table.table.table-hover.table-bordered
+    thead.table-light
       tr
         th= Question.human_attribute_name(:service)
         th= Question.human_attribute_name(:title)

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -24,21 +24,14 @@
       tr
         th= Question.human_attribute_name(:service)
         th= Question.human_attribute_name(:title)
-        th= Question.human_attribute_name(:content)
         th= Question.human_attribute_name(:status)
         th= Question.human_attribute_name(:categories)
         th= Question.human_attribute_name(:created_at)
-        th= Question.human_attribute_name(:updated_at)
-        th= Question.human_attribute_name(:local_government_id)
     tbody
       - @questions.each do |question|
         tr
           td= question.service_i18n
           td= link_to question.title, admin_question_path(question)
-          td= question.content  
           td= question.status_i18n
           td= question.categories.to_human.join(' ')
           td= l question.created_at
-          td= l question.updated_at
-          td= question.local_government_id
-

--- a/app/views/admin/questions/index.html.slim
+++ b/app/views/admin/questions/index.html.slim
@@ -1,39 +1,40 @@
-h1 質問一覧
+.container 
+  h4.my-3 質問一覧
 
-= form_with url: admin_questions_path, local: true do |f|
-  .form-group.row.mt-3
-    = f.label :service, 'サービス種別'
-    .col-sm-4
-      .border.rounded
-        = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
-        { include_blank: true }, class: 'form-control js-searchable'
-  .form-group.my-3
-    = f.label :status, '回答ステータス'
-    = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
-       { include_blank: true }
-  = f.submit nil, value: '検索する', class: 'btn btn-primary'
+  = form_with url: admin_questions_path, local: true do |f|
+    .form-group.row
+      = f.label :service, 'サービス種別'
+      .col-sm-4
+        .border.rounded
+          = f.select :service, Question.services.keys.map {|k| [I18n.t("enums.question.service.#{k}"), k]},\
+          { include_blank: true }, class: 'form-control js-searchable'
+    .form-group.my-3
+      = f.label :status, '回答ステータス'
+      = f.select :status, Question.statuses.keys.map {|k| [I18n.t("enums.question.status.#{k}"), k]},\
+        { include_blank: true }
+    = f.submit nil, value: '検索する', class: 'btn btn-primary'
 
-.my-3
-  table.table.table-hover
-    thead.thead-default
-      tr
-        th= Question.human_attribute_name(:service)
-        th= Question.human_attribute_name(:title)
-        th= Question.human_attribute_name(:content)
-        th= Question.human_attribute_name(:status)
-        th= Question.human_attribute_name(:categories)
-        th= Question.human_attribute_name(:created_at)
-        th= Question.human_attribute_name(:updated_at)
-        th= Question.human_attribute_name(:local_government_id)
-    tbody
-      - @questions.each do |question|
+  .my-3
+    table.table.table-hover
+      thead.thead-default
         tr
-          td= question.service_i18n
-          td= link_to question.title, admin_question_path(question)
-          td= question.content  
-          td= question.status_i18n
-          td= question.categories.to_human.join(' ')
-          td= l question.created_at
-          td= l question.updated_at
-          td= question.local_government_id
+          th= Question.human_attribute_name(:service)
+          th= Question.human_attribute_name(:title)
+          th= Question.human_attribute_name(:content)
+          th= Question.human_attribute_name(:status)
+          th= Question.human_attribute_name(:categories)
+          th= Question.human_attribute_name(:created_at)
+          th= Question.human_attribute_name(:updated_at)
+          th= Question.human_attribute_name(:local_government_id)
+      tbody
+        - @questions.each do |question|
+          tr
+            td= question.service_i18n
+            td= link_to question.title, admin_question_path(question)
+            td= question.content  
+            td= question.status_i18n
+            td= question.categories.to_human.join(' ')
+            td= l question.created_at
+            td= l question.updated_at
+            td= question.local_government_id
 

--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -12,14 +12,16 @@ html
     link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous"
     script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"
   body
-    .app-title.navbar.navbar-expand-lg.navbar-light.bg-light
-      .navbar-brand Q care A 
-
-      ul.navbar-nav.me-auto 
-        - if current_lg 
-          li.nav-item= link_to '質問一覧', admin_questions_path, class: 'nav-link'
-          li.nav-item= link_to 'ログアウト', admin_logout_path, method: :delete, class: 'nav-link'
-      ul.navbar-nav.ms-auto 
-        li.nav-item= current_lg.name 
-    .container
+    .navbar.navbar-expand-lg.navbar-dark.bg-primary
+      .container
+        .navbar-brand Q care A 
+        - if current_lg
+          ul.navbar-nav.me-auto 
+            li.nav-item= link_to '質問トップ', admin_questions_path, class: 'nav-link'
+            li.nav-item= link_to 'ログアウト', admin_logout_path, method: :delete, class: 'nav-link'
+          ul.navbar-nav.ms-auto 
+            li.nav-item= link_to current_lg.name, admin_questions_path, class: 'nav-link'
+        - else 
+          ul.navbar-nav.me-auto
+            li.nav-item= link_to 'ログイン', admin_login_path, class: 'nav-link'
     = yield


### PR DESCRIPTION
## 概要
役所側の質問一覧ページに対し、Bootstrapを用いてデザインを調整した

## 実装内容
- navbarのデザインを修正した
- 絞り込みフォームを水平に揃えた
- テスト用に表示していた一覧ページに不要なカラムを削除した（編集できない仕様なので、更新日時の削除等）
- 表全体のデザインを修正した

## 実行結果
修正後の質問フォーム
<img width="1406" alt="スクリーンショット 2022-11-01 11 53 29" src="https://user-images.githubusercontent.com/112605644/199148924-914dfcea-90ea-4dbb-9f8e-4591dd4b129c.png">

