### PR TITLE
[役所]回答作成ページのデザインの修正

### DIFF
--- a/app/views/admin/questions/show.html.slim
+++ b/app/views/admin/questions/show.html.slim
@@ -27,22 +27,19 @@
           tr 
             th.bg-light= Question.human_attribute_name(:created_at)
             td= l @question.created_at
-
-  - if @question.answer.nil?
-    = form_with model: [:admin, @question, @question.build_answer], local: true do |f|
-      .form-group 
-        = f.label :title
-        = f.text_field :title, class: 'form-control'
-      .form-group
-        = f.label :content
-        = f.text_area :content, rows: 5, class: 'form-control'
-      .d-grid.gap-2.col-3.mx-auto.my-3
-        = f.submit nil, name: 'update', value: '回答する', class: 'btn btn-primary'
-    .d-grid.gap-2.col-3.mx-auto.my-3
-      = link_to '作成中', admin_question_activenesses_path(@question), method: 'post', class: 'btn btn-primary'
-  - else 
-    .row 
-      .col-10
+      - if @question.answer.nil?
+        = form_with model: [:admin, @question, @question.build_answer], local: true do |f|
+          .form-group 
+            = f.label :title, class: 'mb-2'
+            = f.text_field :title, class: 'form-control mb-3'
+          .form-group
+            = f.label :content, class: 'mb-2'
+            = f.text_area :content, rows: 5, class: 'form-control mb-4'
+          .d-grid.gap-2.col-3.mx-auto
+            = f.submit nil, name: 'update', value: '回答する', class: 'btn btn-primary'
+        .d-grid.gap-2.col-3.mx-auto.my-3
+          = link_to '作成中', admin_question_activenesses_path(@question), method: 'post', class: 'btn btn-secondary'
+      - else 
         table.mb-4.table.table-hover.table-bordered
           tbody 
             tr 

--- a/app/views/admin/questions/show.html.slim
+++ b/app/views/admin/questions/show.html.slim
@@ -1,61 +1,61 @@
-h1 回答画面
+.container
+  h3.my-4 回答フォーム
+  hr
 
-.nav.justify-content-end
-  = link_to '質問一覧に戻る', admin_questions_path, class: 'nav-link'
+  .nav.justify-content-end
+    = link_to '質問一覧に戻る', admin_questions_path, class: 'nav-link'
 
-h3 質問内容
-table.table.table-hover 
-  tbody 
-    tr 
-      th= Question.human_attribute_name(:id)
-      td= @question.id
-    tr 
-      th= Question.human_attribute_name(:title)
-      td= @question.title
-    tr 
-      th= Question.human_attribute_name(:content)
-      td= @question.content
-    tr 
-      th= Question.human_attribute_name(:status)
-      td= @question.status_i18n
-    tr 
-      th= Question.human_attribute_name(:categories)
-      td= @question.categories.to_human.join(' ')
-    tr 
-      th= Question.human_attribute_name(:created_at)
-      td= l @question.created_at
-    tr 
-      th= Question.human_attribute_name(:updated_at)
-      td= l @question.updated_at
-
-- if @question.answer.nil?
-  = form_with model: [:admin, @question, @question.build_answer], local: true do |f|
-    .form-group 
-      = f.label :title
-      = f.text_field :title, class: 'form-control'
-    .form-group
-      = f.label :content
-      = f.text_area :content, rows: 5, class: 'form-control'
-    .d-grid.gap-2.col-3.mx-auto.my-3
-      = f.submit nil, name: 'update', value: '回答する', class: 'btn btn-primary'
-  .d-grid.gap-2.col-3.mx-auto.my-3
-    = link_to '作成中', admin_question_activenesses_path(@question), method: 'post', class: 'btn btn-primary'
-- else 
-  table.table.table-hover 
-    h3 回答内容
-    tbody 
+  table.mb-4.table.table-hover
+    tbody
       tr 
         th= Question.human_attribute_name(:id)
-        td= @question.answer.id
+        td= @question.id
       tr 
         th= Question.human_attribute_name(:title)
-        td= @question.answer.title
+        td= @question.title
       tr 
         th= Question.human_attribute_name(:content)
-        td= @question.answer.content 
+        td= @question.content
+      tr 
+        th= Question.human_attribute_name(:status)
+        td= @question.status_i18n
+      tr 
+        th= Question.human_attribute_name(:categories)
+        td= @question.categories.to_human.join(' ')
       tr 
         th= Question.human_attribute_name(:created_at)
-        td= l @question.answer.created_at
+        td= l @question.created_at
       tr 
         th= Question.human_attribute_name(:updated_at)
-        td= l @question.answer.updated_at
+        td= l @question.updated_at
+
+  - if @question.answer.nil?
+    = form_with model: [:admin, @question, @question.build_answer], local: true do |f|
+      .form-group 
+        = f.label :title
+        = f.text_field :title, class: 'form-control'
+      .form-group
+        = f.label :content
+        = f.text_area :content, rows: 5, class: 'form-control'
+      .d-grid.gap-2.col-3.mx-auto.my-3
+        = f.submit nil, name: 'update', value: '回答する', class: 'btn btn-primary'
+    .d-grid.gap-2.col-3.mx-auto.my-3
+      = link_to '作成中', admin_question_activenesses_path(@question), method: 'post', class: 'btn btn-primary'
+  - else 
+    table.table.table-hover
+      tbody 
+        tr 
+          th= Question.human_attribute_name(:id)
+          td= @question.answer.id
+        tr 
+          th= Question.human_attribute_name(:title)
+          td= @question.answer.title
+        tr 
+          th= Question.human_attribute_name(:content)
+          td= @question.answer.content 
+        tr 
+          th= Question.human_attribute_name(:created_at)
+          td= l @question.answer.created_at
+        tr 
+          th= Question.human_attribute_name(:updated_at)
+          td= l @question.answer.updated_at

--- a/app/views/admin/questions/show.html.slim
+++ b/app/views/admin/questions/show.html.slim
@@ -5,29 +5,31 @@
   .nav.justify-content-end
     = link_to '質問一覧に戻る', admin_questions_path, class: 'nav-link'
 
-  table.mb-4.table.table-hover
-    tbody
-      tr 
-        th= Question.human_attribute_name(:id)
-        td= @question.id
-      tr 
-        th= Question.human_attribute_name(:title)
-        td= @question.title
-      tr 
-        th= Question.human_attribute_name(:content)
-        td= @question.content
-      tr 
-        th= Question.human_attribute_name(:status)
-        td= @question.status_i18n
-      tr 
-        th= Question.human_attribute_name(:categories)
-        td= @question.categories.to_human.join(' ')
-      tr 
-        th= Question.human_attribute_name(:created_at)
-        td= l @question.created_at
-      tr 
-        th= Question.human_attribute_name(:updated_at)
-        td= l @question.updated_at
+  .row 
+    .col-10
+      table.mb-4.table.table-hover.table-bordered
+        tbody
+          tr
+            th.bg-light style= "width: 20%"= Question.human_attribute_name(:id)
+            td= @question.id
+          tr 
+            th.bg-light= Question.human_attribute_name(:title)
+            td= @question.title
+          tr 
+            th.bg-light= Question.human_attribute_name(:content)
+            td= @question.content
+          tr 
+            th.bg-light= Question.human_attribute_name(:status)
+            td= @question.status_i18n
+          tr 
+            th.bg-light= Question.human_attribute_name(:categories)
+            td= @question.categories.to_human.join(' ')
+          tr 
+            th.bg-light= Question.human_attribute_name(:created_at)
+            td= l @question.created_at
+          tr 
+            th.bg-light= Question.human_attribute_name(:updated_at)
+            td= l @question.updated_at
 
   - if @question.answer.nil?
     = form_with model: [:admin, @question, @question.build_answer], local: true do |f|
@@ -42,20 +44,22 @@
     .d-grid.gap-2.col-3.mx-auto.my-3
       = link_to '作成中', admin_question_activenesses_path(@question), method: 'post', class: 'btn btn-primary'
   - else 
-    table.table.table-hover
-      tbody 
-        tr 
-          th= Question.human_attribute_name(:id)
-          td= @question.answer.id
-        tr 
-          th= Question.human_attribute_name(:title)
-          td= @question.answer.title
-        tr 
-          th= Question.human_attribute_name(:content)
-          td= @question.answer.content 
-        tr 
-          th= Question.human_attribute_name(:created_at)
-          td= l @question.answer.created_at
-        tr 
-          th= Question.human_attribute_name(:updated_at)
-          td= l @question.answer.updated_at
+    .row 
+      .col-10
+        table.mb-4.table.table-hover.table-bordered
+          tbody 
+            tr 
+              th.bg-light style= "width: 20%"= Question.human_attribute_name(:id)
+              td= @question.answer.id
+            tr 
+              th.bg-light= Question.human_attribute_name(:title)
+              td= @question.answer.title
+            tr 
+              th.bg-light= Question.human_attribute_name(:content)
+              td= @question.answer.content 
+            tr 
+              th.bg-light= Question.human_attribute_name(:created_at)
+              td= l @question.answer.created_at
+            tr 
+              th.bg-light= Question.human_attribute_name(:updated_at)
+              td= l @question.answer.updated_at

--- a/app/views/admin/questions/show.html.slim
+++ b/app/views/admin/questions/show.html.slim
@@ -27,9 +27,6 @@
           tr 
             th.bg-light= Question.human_attribute_name(:created_at)
             td= l @question.created_at
-          tr 
-            th.bg-light= Question.human_attribute_name(:updated_at)
-            td= l @question.updated_at
 
   - if @question.answer.nil?
     = form_with model: [:admin, @question, @question.build_answer], local: true do |f|
@@ -49,17 +46,14 @@
         table.mb-4.table.table-hover.table-bordered
           tbody 
             tr 
-              th.bg-light style= "width: 20%"= Question.human_attribute_name(:id)
+              th.bg-light style= "width: 20%"= Answer.human_attribute_name(:id)
               td= @question.answer.id
             tr 
-              th.bg-light= Question.human_attribute_name(:title)
+              th.bg-light= Answer.human_attribute_name(:title)
               td= @question.answer.title
             tr 
-              th.bg-light= Question.human_attribute_name(:content)
+              th.bg-light= Answer.human_attribute_name(:content)
               td= @question.answer.content 
             tr 
-              th.bg-light= Question.human_attribute_name(:created_at)
+              th.bg-light= Answer.human_attribute_name(:created_at)
               td= l @question.answer.created_at
-            tr 
-              th.bg-light= Question.human_attribute_name(:updated_at)
-              td= l @question.answer.updated_at

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,20 +21,20 @@ ja:
           error: 過誤調整
     attributes:
       question:
-        id: ID
-        title: 質問タイトル
-        content: 質問本文
-        status: 回答ステータス
+        id: 質問ID
+        title: タイトル
+        content: 本文
+        status: ステータス
         created_at: 質問日時
         updated_at: 更新日時
         local_government_id: 役所ID
         service: サービス種別
         nursing_facility_id: 施設ID
-        categories: 質問タグ
+        categories: タグ
       answer:
-        id: ID
-        title: 回答タイトル
-        content: 回答本文
+        id: 回答ID
+        title: タイトル
+        content: 本文
         created_at: 回答日時
         updated_at: 回答更新日時
       staff:


### PR DESCRIPTION
## 概要
役所側の回答作成ページに対し、Bootstrapを用いてデザインを調整した

## 実装内容
- 質問と回答の詳細を表示するtableのデザインを修正した
- 回答フォームのデザインを修正した
- 不要なカラム表示を削除し、カラムの表示名を変更した

## 実行結果
- 回答済みのページ
<img width="1406" alt="スクリーンショット 2022-11-01 16 20 03" src="https://user-images.githubusercontent.com/112605644/199181299-66d7024f-8afa-4291-bf61-0a1344f909b5.png">

- 未回答のページ（回答フォーム）
<img width="1406" alt="スクリーンショット 2022-11-01 16 20 43" src="https://user-images.githubusercontent.com/112605644/199181341-9af5654c-de83-43cf-9fa5-ca03c8d14e80.png">
