### PR TITLE
[役所]ログインページのデザインの修正

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,4 +1,5 @@
 class Admin::SessionsController < Admin::ApplicationController
+  layout 'admin'
   skip_before_action :admin_login_required
 
   def new; end

--- a/app/views/admin/sessions/new.html.slim
+++ b/app/views/admin/sessions/new.html.slim
@@ -1,13 +1,17 @@
-h1 市区町村ログイン
+.container
+  .text-center
+    h3.my-4 自治体ログイン
 
-= form_with scope: :session, local: true do |f|
-  .form-group
-    = f.label :name, '市区町村名'
-    = f.text_field :name, class: 'form-control', id: 'session-name'
-  .form-group 
-    = f.label :email, 'メールアドレス'
-    = f.text_field :email, class: 'form-control', id: 'session-email'
-  .form-group 
-    = f.label :password, 'パスワード'
-    = f.text_field :password, class: 'form-control', id: 'session-password'
-  = f.submit 'ログインする', class: 'btn btn-primary'
+    = form_with scope: :session, local: true do |f|
+      .row.justify-content-center
+        .col-sm-4
+          .form-group
+            = f.label :name, '市区町村名'
+            = f.text_field :name, class: 'form-control', id: 'session-name'
+          .form-group 
+            = f.label :email, 'メールアドレス'
+            = f.text_field :email, class: 'form-control', id: 'session-email'
+          .form-group 
+            = f.label :password, 'パスワード'
+            = f.text_field :password, class: 'form-control', id: 'session-password'
+          = f.submit 'ログインする', class: 'btn btn-primary'

--- a/app/views/admin/sessions/new.html.slim
+++ b/app/views/admin/sessions/new.html.slim
@@ -6,12 +6,12 @@
       .row.justify-content-center
         .col-sm-4
           .form-group
-            = f.label :name, '市区町村名'
-            = f.text_field :name, class: 'form-control', id: 'session-name'
+            = f.label :name, '市区町村名', class: 'mb-2', for: 'session-name'
+            = f.text_field :name, class: 'form-control mb-3', id: 'session-name', placeholder: "市区町村"
           .form-group 
-            = f.label :email, 'メールアドレス'
-            = f.text_field :email, class: 'form-control', id: 'session-email'
+            = f.label :email, 'メールアドレス', class: 'mb-2', for: 'session-email'
+            = f.text_field :email, class: 'form-control mb-3', id: 'session-email', placeholder: "Email address"
           .form-group 
-            = f.label :password, 'パスワード'
-            = f.text_field :password, class: 'form-control', id: 'session-password'
-          = f.submit 'ログインする', class: 'btn btn-primary'
+            = f.label :password, 'パスワード', class: 'mb-2', for: 'session-password'
+            = f.password_field :password, class: 'form-control mb-4', id: 'session-password', placeholder: "Password"
+          = f.submit 'ログイン', class: 'btn btn-primary'

--- a/app/views/admin/sessions/new.html.slim
+++ b/app/views/admin/sessions/new.html.slim
@@ -5,9 +5,6 @@
     = form_with scope: :session, local: true do |f|
       .row.justify-content-center
         .col-sm-4
-          .form-group
-            = f.label :name, '市区町村名', class: 'mb-2', for: 'session-name'
-            = f.text_field :name, class: 'form-control mb-3', id: 'session-name', placeholder: "市区町村"
           .form-group 
             = f.label :email, 'メールアドレス', class: 'mb-2', for: 'session-email'
             = f.text_field :email, class: 'form-control mb-3', id: 'session-email', placeholder: "Email address"


### PR DESCRIPTION
## 概要
役所側のログインページに対し、Bootstrapを用いてデザインを調整した

## 実装内容
- 全体のデザインと余白を修正した
- 不要なフォームを削除した

## 実行結果
修正後のページ
<img width="1406" alt="スクリーンショット 2022-11-02 10 11 06" src="https://user-images.githubusercontent.com/112605644/199371314-bd2d689a-ecc9-4631-9fb5-44766486745d.png">
