### PR TITLE
[介護]職員の新規登録ページのデザインの修正

### DIFF
--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -7,7 +7,8 @@ class StaffsController < ApplicationController
     @staff = Staff.new(staff_params)
 
     if @staff.save
-      redirect_to staff_url(@staff), notice: "職員「#{@staff.name}」を登録しました。"
+      session[:staff_id] = @staff.id
+      redirect_to root_url, notice: "職員「#{@staff.name}」を登録しました。"
     else
       render :new
     end

--- a/app/views/staffs/new.html.slim
+++ b/app/views/staffs/new.html.slim
@@ -1,22 +1,19 @@
-h1 介護職員登録
+.container
+  .text-center
+    h3.my-4 新規登録
 
-.nav.justify-content-end 
-  = link_to '職員一覧', staffs_path, class: 'nav-link'
-
-= form_with model: @staff, local: true do |f|
-  .form-group 
-    = f.label :name, '名前'
-    = f.text_field :name, class: 'form-control'
-  .form-group 
-    = f.label :email, 'メールアドレス'
-    = f.text_field :email, class: 'form-control'
-  .form-group 
-    = f.label :nursing_facility_id, '介護施設ID'
-    = f.text_field :nursing_facility_id, class: 'form-control'
-  .form-group 
-    = f.label :password, 'パスワード'
-    = f.text_field :password, class: 'form-control'
-  .form-group 
-    = f.label :password_confirmation, 'パスワード（確認）'
-    = f.text_field :password_confirmation, class: 'form-control'
-  = f.submit '登録する', class: 'btn btn-primary'
+  = form_with model: @staff, local: true do |f|
+    .row.justify-content-center
+      .col-sm-4
+        .form-group
+          = f.label :name, '名前', class: 'mb-2'
+          = f.text_field :name, class: 'form-control mb-3'
+          = f.label :email, 'メールアドレス', class: 'mb-2'
+          = f.text_field :email, class: 'form-control mb-3'
+          = f.label :nursing_facility_id, '介護施設ID', class: 'mb-2'
+          = f.text_field :nursing_facility_id, class: 'form-control mb-3'
+          = f.label :password, 'パスワード', class: 'mb-2'
+          = f.text_field :password, class: 'form-control mb-3'
+          = f.label :password_confirmation, 'パスワード（確認）', class: 'mb-2'
+          = f.text_field :password_confirmation, class: 'form-control mb-5'
+        = f.submit '登録する', class: 'btn btn-primary mx-auto d-block'


### PR DESCRIPTION
## 概要
介護側の新規登録ページに対し、Bootstrapを用いてデザインを調整した

## 実装内容
- 全体のデザインと余白を修正した
- 登録完了時、root（質問一覧ページ）に遷移するようにした

## 実行結果
修正後のページ
<img width="1406" alt="スクリーンショット 2022-11-02 16 38 14" src="https://user-images.githubusercontent.com/112605644/199428659-2afe86af-cdd3-4bbf-a563-38db26736dbc.png">
